### PR TITLE
Enabled Python syntax highlighting for code blocks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The code is not very concise, but is reasonably clear.
 
 The version of this example given in PEP 626 is as follows:
 
-```
+```python
 match value:
     case [*v, label := (Promise() | str())] if v:
         value = tuple(v)
@@ -103,7 +103,7 @@ Also note:
 The match version has different semantics. This has been pointed out to the PEP's authors but they have so far declined to either update the example or state in the PEP that the semantics are different.
 If the exact semantics are to be retained, then the PEP 626 example should read
 
-```
+```python
 match value:
     case [*v, label := (Promise() | str())] if v and isinstance(value, (list, tuple)):
         value = tuple(v)
@@ -114,7 +114,7 @@ match value:
 
 ### is_tuple example
 
-```
+```python
 def is_tuple(node):
     if isinstance(node, Node) and node.children == [LParen(), RParen()]:
         return True
@@ -129,7 +129,7 @@ def is_tuple(node):
 
 PEP 626 shows this example rewritten as:
 
-```
+```python
 def is_tuple(node: Node) -> bool:
     match node:
         case Node(children=[LParen(), RParen()]):
@@ -143,7 +143,7 @@ def is_tuple(node: Node) -> bool:
 This is merely taking code that is a bit verbose and rewriting it more concisely.
 We can already do this in Python 3.9:
 
-```
+```python
 def is_tuple(node):
     if isinstance(node, Node):
         l, *n, r = node.children
@@ -156,7 +156,7 @@ which is shorter, arguably clearer, and needs no new syntax.
 
 ### HTTP response example
 
-```
+```python
 match response.status:
     case 200:
         do_something(response.data)  # OK
@@ -175,7 +175,7 @@ The final example is a simple switch statement, and shows that there may be some
 switch-statement-like functionality to Python.
 However, PEP 626 prevents the use of simple symbolic constants, so the statement *cannot* be written as
 
-```
+```python
 match response.status:
     case HTTP_OK:
         do_something(response.data)  # OK


### PR DESCRIPTION
Hi Mark,

Some of the code blocks in the README didn't have syntax highlighting, which made them harder to read. 

I've enabled highlighting for all of them.